### PR TITLE
Fix DNS record editing

### DIFF
--- a/DigitalOceanSwimmer/src/main/java/com/yassirh/digitalocean/ui/RecordCreateDialogFragment.java
+++ b/DigitalOceanSwimmer/src/main/java/com/yassirh/digitalocean/ui/RecordCreateDialogFragment.java
@@ -130,33 +130,33 @@ public class RecordCreateDialogFragment extends DialogFragment {
 		
 		if(record != null){
 			if(record.getRecordType().equals("SRV")){
-				recordTypeSpinner.setSelection(0);
+				recordTypeSpinner.setSelection(1);
 				srvNameEditText.setText(record.getName());
 				srvHostnameEditText.setText(record.getData());
 				srvPriorityEditText.setText(record.getPriority() + "");
 				srvPortEditText.setText(record.getPort() + "");
 				srvWeightEditText.setText(record.getWeight() + "");
 			}else if(record.getRecordType().equals("MX")){
-				recordTypeSpinner.setSelection(1);
+				recordTypeSpinner.setSelection(3);
 				mxHostnameEditText.setText(record.getData());
 				mxPriorityEditText.setText(record.getPriority() + "");
 			}else if(record.getRecordType().equals("NS")){
-				recordTypeSpinner.setSelection(2);
+				recordTypeSpinner.setSelection(0);
 				nsHostnameEditText.setText(record.getData());
 			}else if(record.getRecordType().equals("CNAME")){
-				recordTypeSpinner.setSelection(3);
+				recordTypeSpinner.setSelection(4);
 				cnameNameEditText.setText(record.getName());
 				cnameHostnameEditText.setText(record.getData());				
 			}else if(record.getRecordType().equals("TXT")){
-				recordTypeSpinner.setSelection(4);
+				recordTypeSpinner.setSelection(2);
 				txtNameEditText.setText(record.getName());
 				txtTextEditText.setText(record.getData());
 			}else if(record.getRecordType().equals("A")){
-				recordTypeSpinner.setSelection(6);
+				recordTypeSpinner.setSelection(5);
 				aHostnameEditText.setText(record.getName());
 				aIpAddressEditText.setText(record.getData());
 			}else if(record.getRecordType().equals("AAAA")){
-				recordTypeSpinner.setSelection(5);
+				recordTypeSpinner.setSelection(6);
 				aaaaHostnameEditText.setText(record.getName());
 				aaaaIpAddressEditText.setText(record.getData());
 			}

--- a/DigitalOceanSwimmer/src/main/java/com/yassirh/digitalocean/ui/RecordTypeAdapter.java
+++ b/DigitalOceanSwimmer/src/main/java/com/yassirh/digitalocean/ui/RecordTypeAdapter.java
@@ -1,6 +1,6 @@
 package com.yassirh.digitalocean.ui;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import com.yassirh.digitalocean.R;
 
@@ -15,7 +15,7 @@ import android.widget.ImageView;
 
 public class RecordTypeAdapter extends BaseAdapter {
 
-    public static HashMap<String, Integer> sData = new HashMap<String, Integer>();
+    public static LinkedHashMap<String, Integer> sData = new LinkedHashMap<String, Integer>();
     
     static{
     	sData.put("ns", R.drawable.ns);


### PR DESCRIPTION
Fixes #39

When a record is edited the `recordTypeSpinner` should be moved to the
matching record type.  In order to refer to the values by position index
we need to ensure the order of the values.  Since a `HashMap` does not
ensure the order of the values, the position of the `A` record for
instance is not predictable.  By converting to a `LinkedHashMap` the order
is ensured and we can set the selection by position.